### PR TITLE
Only add sources if the type is supported by a Tech

### DIFF
--- a/lib/videojs-resolution-switcher.js
+++ b/lib/videojs-resolution-switcher.js
@@ -115,6 +115,15 @@
         //Return current src if src is not given
         if(!src){ return player.src(); }
 
+        // Only add those sources which we can (maybe) play
+        src = src.filter( function(source) {
+          try {
+            return ( player.canPlayType( source.type ) !== '' );
+          } catch (e) {
+            // If a Tech doesn't yet have canPlayType just add it
+            return true;
+          }
+        });
         // Sort sources
         this.currentSources = src.sort(compareResolutions);
         this.groupedSrc = bucketSources(this.currentSources);


### PR DESCRIPTION
There is not much use in adding sources that we cannot play, so filter
them out. Backwards compatible with Tech's that do not yet support
canPlayType().
